### PR TITLE
Install option fixed on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Installation
 
 To install Whatson run the Elasticsearch plugin installer on any node:
 
-    bin/plugin -install xyu/elasticsearch-whatson/0.1.3
+    bin/plugin install xyu/elasticsearch-whatson/0.1.3
 
 Access the plugin by going to the Whatson plugin site. (E.g. http://localhost:9200/_plugin/whatson/)
 


### PR DESCRIPTION
Hi.

When I run `bin/plugin -install ...`, I get an error:

```
$ bin/plugin -install xyu/elasticsearch-whatson/0.1.3
ERROR: unknown command [-install]. Use [-h] option to list available commands
```

I think `bin/plugin install` is right.

Thanks.