### PR TITLE
Allow passing the ES url as a parameter.

### DIFF
--- a/_site/assets/js/app.js
+++ b/_site/assets/js/app.js
@@ -24,6 +24,9 @@
 			if ( '/_plugin/whatson' == window.location.pathname.substr(0,16) ) {
 				// Running as ES site plugin
 				self._info.host = window.location.protocol + '//' + window.location.host;
+			} else if ( window.location.search.startsWith("?base_uri=") ) {
+				// ES url passed as a parameter
+				self._info.host = window.location.search.substr(10);
 			} else {
 				// Running elsewhere
 				self._info.host = '';


### PR DESCRIPTION
This enables direct linking to stats of different ES clusters. 

Example url:
http://anand.com:8000/_site/?base_url=http://myesServer:9200